### PR TITLE
增加对乐视网的支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ pptv下载
 乐视网下载
 --------
 
-        python letv.py urls...
+	python letv.py urls...
 
 其他下载
 --------

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ pptv下载
 
 	python sohu.py urls...
 
+乐视网下载
+--------
+
+        python letv.py urls...
+
 其他下载
 --------
 

--- a/letv.py
+++ b/letv.py
@@ -17,7 +17,7 @@ def get_title(s1):
     pos = o1.group(1).rfind(suffix)
     if -1 != pos:
         title = title[:pos]
-    return title.decode('utf-8')
+    return title.decode('utf-8') #return unicode
     
 def letv_download(url):
     s1 = get_html(url)

--- a/letv.py
+++ b/letv.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+__all__ = ['letv_download']
+
+from common import *
+import re,base64,json
+
+#http://www.letv.com/ptv/pplay/5938/1.html
+
+def letv_download(url):
+    s1 = get_html(url)
+    o1 = re.search(r'''<div[^<>]*?id=.?j-videoplay.*?<script>.*?{\s*v:[[]["']([^\s]+?)["']''',s1,re.I|re.S)
+    url1 = o1.group(1)#http://g3.letv.cn/4/34/89/204323373.0.flv?b=269&tag=ios&np=1&vtype=m3u8
+    url1 = base64.b64decode(url1)
+    #http://g3.letv.cn/vod/v1/NC8zNC84OS8yMDQzMjMzNzMuMC5mbHY=?format=1&b=269&expect=3&host=www_letv_com
+    prefix = 'http://g3.letv.cn/'
+    url1 = url1.replace(prefix,'',1)
+    pos1 = url1.find('?')
+    url1 = url1[:pos1]
+    url2 = prefix + 'vod/v1/' + base64.b64encode(url1) + '?format=1&b=269&expect=3&host=www_letv_com'
+    o2 = json.loads(get_html(url2))
+    baseurl = o2['nodelist'][0]['location']
+    urls = [] 
+    curr_pos = 0
+    for i,each in enumerate(o2['nodelist']):
+        new_url = baseurl + '&begin=' + str(curr_pos) + '&stop=' + str(curr_pos + each['gone']) + '&cLoadID=' + str(i+1)
+        curr_pos += each['gone']
+        urls.append(new_url)
+    for each in  urls:
+        print each
+    title = 'test'
+    download_urls(urls,title,'flv',total_size=None)
+
+
+download = letv_download
+download_playlist = playlist_not_supported('letv')
+
+def main():
+    script_main('letv',letv_download)
+
+if __name__ == '__main__':
+    main()
+

--- a/letv.py
+++ b/letv.py
@@ -3,7 +3,7 @@
 __all__ = ['letv_download']
 
 from common import *
-import re,base64,json
+import re, base64, json
 
 #http://www.letv.com/ptv/pplay/5938/1.html
 
@@ -17,13 +17,13 @@ def get_title(s1):
     pos = o1.group(1).rfind(suffix)
     if -1 != pos:
         title = title[:pos]
-    return title
+    return title.decode('utf-8')
     
 def letv_download(url):
     s1 = get_html(url)
     p1 = r'''<div[^<>]*?id=.?j-videoplay.*?<script>.*?{\s*v:[[]["']([^\s]+?)["']'''
     o1 = re.search(p1,s1,re.I|re.S)
-    url1 = o1.group(1)#http://g3.letv.cn/4/34/89/204323373.0.flv?b=269&tag=ios&np=1&vtype=m3u8
+    url1 = o1.group(1) #http://g3.letv.cn/4/34/89/204323373.0.flv?b=269&tag=ios&np=1&vtype=m3u8
     url1 = base64.b64decode(url1)
     prefix = 'http://g3.letv.cn/'
     url1 = url1.replace(prefix,'',1)
@@ -35,12 +35,8 @@ def letv_download(url):
     o2 = json.loads(get_html(url2))
     baseurl = o2['nodelist'][0]['location']
     urls = [] 
-    curr_pos = 0
-    for i,each in enumerate(o2['nodelist']):
-        new_url = baseurl + '&begin=' + str(curr_pos) + '&stop=' +\
-            str(curr_pos + each['gone']) + '&cLoadID=' + str(i+1)
-        curr_pos += each['gone']
-        urls.append(new_url)
+    new_url = baseurl + '&begin=0' + '&cLoadID=-1'
+    urls.append(new_url)
     title = get_title(s1)
     download_urls(urls,title,'flv',total_size=None)
 

--- a/letv.py
+++ b/letv.py
@@ -7,28 +7,41 @@ import re,base64,json
 
 #http://www.letv.com/ptv/pplay/5938/1.html
 
+def get_title(s1):
+    #get title
+    p1 = r'<\s*title\s*>\s*(.*?)\s*<\s*/\s*title\s*>'
+    o1 = re.search(p1,s1,re.I|re.S)
+    assert(o1)
+    title = o1.group(1)
+    suffix = ' - \xe5\x9c\xa8\xe7\xba\xbf\xe8\xa7\x82\xe7\x9c\x8b - \xe4\xb9\x90\xe8\xa7\x86\xe7\xbd\x91'
+    pos = o1.group(1).rfind(suffix)
+    if -1 != pos:
+        title = title[:pos]
+    return title
+    
 def letv_download(url):
     s1 = get_html(url)
-    o1 = re.search(r'''<div[^<>]*?id=.?j-videoplay.*?<script>.*?{\s*v:[[]["']([^\s]+?)["']''',s1,re.I|re.S)
+    p1 = r'''<div[^<>]*?id=.?j-videoplay.*?<script>.*?{\s*v:[[]["']([^\s]+?)["']'''
+    o1 = re.search(p1,s1,re.I|re.S)
     url1 = o1.group(1)#http://g3.letv.cn/4/34/89/204323373.0.flv?b=269&tag=ios&np=1&vtype=m3u8
     url1 = base64.b64decode(url1)
-    #http://g3.letv.cn/vod/v1/NC8zNC84OS8yMDQzMjMzNzMuMC5mbHY=?format=1&b=269&expect=3&host=www_letv_com
     prefix = 'http://g3.letv.cn/'
     url1 = url1.replace(prefix,'',1)
     pos1 = url1.find('?')
     url1 = url1[:pos1]
-    url2 = prefix + 'vod/v1/' + base64.b64encode(url1) + '?format=1&b=269&expect=3&host=www_letv_com'
+    url2 = prefix + 'vod/v1/' + base64.b64encode(url1) +\
+        '?format=1&b=269&expect=3&host=www_letv_com'
+    #http://g3.letv.cn/vod/v1/NC8zNC84OS8yMDQzMjMzNzMuMC5mbHY=?format=1&b=269&expect=3&host=www_letv_com
     o2 = json.loads(get_html(url2))
     baseurl = o2['nodelist'][0]['location']
     urls = [] 
     curr_pos = 0
     for i,each in enumerate(o2['nodelist']):
-        new_url = baseurl + '&begin=' + str(curr_pos) + '&stop=' + str(curr_pos + each['gone']) + '&cLoadID=' + str(i+1)
+        new_url = baseurl + '&begin=' + str(curr_pos) + '&stop=' +\
+            str(curr_pos + each['gone']) + '&cLoadID=' + str(i+1)
         curr_pos += each['gone']
         urls.append(new_url)
-    for each in  urls:
-        print each
-    title = 'test'
+    title = get_title(s1)
     download_urls(urls,title,'flv',total_size=None)
 
 

--- a/tudou.py
+++ b/tudou.py
@@ -27,7 +27,8 @@ def tudou_download(url):
 	html = get_decoded_html(url)
 	iid = r1(r'iid\s*[:=]\s*(\d+)', html)
 	assert iid
-	title = r1(r'title\s*[:=]\s*"([^"]+)"\n', html)
+	#title = r1(r'title\s*[:=]\s*"([^"]+)"\n', html)
+    title = r1(r'<title>(.*?)</title>', html)
 	assert title
 	title = unescape_html(title)
 	tudou_download_by_iid(iid, title)

--- a/tudou.py
+++ b/tudou.py
@@ -28,7 +28,7 @@ def tudou_download(url):
 	iid = r1(r'iid\s*[:=]\s*(\d+)', html)
 	assert iid
 	#title = r1(r'title\s*[:=]\s*"([^"]+)"\n', html)
-    title = r1(r'<title>(.*?)</title>', html)
+	title = r1(r'<title>(.*?)</title>', html)
 	assert title
 	title = unescape_html(title)
 	tudou_download_by_iid(iid, title)


### PR DESCRIPTION
比如
python letv.py http://www.letv.com/ptv/pplay/5938/645.html

不过好像乐视网下载的flv都存在播放无法seek的问题 用ffmpeg转一下了。。。

$ ffmpeg  -sameq   -i "柯南TV645-8张素描画记忆之旅 仓敷篇.flv"   test.avi
