### PR TITLE
修复B站id获取错误

### DIFF
--- a/bilibili.py
+++ b/bilibili.py
@@ -72,6 +72,7 @@ def bilibili_download(url, merge=True):
 	flashvars = r1_of([r'flashvars="([^"]+)"', r'"https://secure.bilibili.tv/secure,(cid=\d+)"'], html)
 	assert flashvars
 	t, id = flashvars.split('=', 1)
+	id = id.split('&')[0]
 	if t == 'cid':
 		bilibili_download_by_cid(id, title, merge=merge)
 	elif t == 'vid':


### PR DESCRIPTION
解析B站视频的id有冗余，例如：
http://www.bilibili.tv/video/av400044/
的id会解析为“613646&aid=400044”(应为“613646”)，使用该id不会影响视频下载，但会导致无法正确下载弹幕文件。
